### PR TITLE
reordering items frontend commit

### DIFF
--- a/PlotLine/PlotLine/Models/GroceryList.swift
+++ b/PlotLine/PlotLine/Models/GroceryList.swift
@@ -14,7 +14,7 @@ struct GroceryList: Identifiable, Codable {
     var username: String // Include username to associate the list with the user
 }
 
-struct GroceryItem: Codable {
+struct GroceryItem: Identifiable, Codable {
     var id: UUID
     var name: String
     var quantity: Int

--- a/PlotLine/PlotLine/Networking/GroceryAPI.swift
+++ b/PlotLine/PlotLine/Networking/GroceryAPI.swift
@@ -179,4 +179,29 @@ struct GroceryListAPI {
             throw error
         }
     }
+    
+    // Function to update the order of items in a grocery list
+    static func updateItemOrder(listId: String, reorderedItems: [GroceryItem]) async throws {
+        guard let loggedInUsername = UserDefaults.standard.string(forKey: "loggedInUsername") else {
+            throw URLError(.userAuthenticationRequired)
+        }
+
+        guard let url = URL(string: "\(baseURL)/\(listId)/items/order?username=\(loggedInUsername)") else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(reorderedItems)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
+        // Assuming server responds with success message
+        print("Items reordered: \(String(data: data, encoding: .utf8) ?? "")")
+    }
 }


### PR DESCRIPTION
Frontend updates

- Users can now reoder items in their grocery list and the order will be persisted in the backend so they can exit the list, re-enter it and the order will be maintained